### PR TITLE
新增小工具：配置文件生成器

### DIFF
--- a/docs/.vuepress/components/Funcs/CopyText.ts
+++ b/docs/.vuepress/components/Funcs/CopyText.ts
@@ -2,6 +2,7 @@ export default function copyText(text) {
     try {
         if (navigator.clipboard) {
             navigator.clipboard.writeText(text); // use navigator.clipboard
+            return true;
         } else {
             var textarea = document.createElement("textarea");
             document.body.appendChild(textarea);
@@ -15,8 +16,10 @@ export default function copyText(text) {
             document.execCommand("copy", true);
             // remove the input area
             document.body.removeChild(textarea);
+            return true;
         }
     } catch (err) {
         console.log(err);
+        return false;
     }
 }

--- a/docs/.vuepress/components/Funcs/CopyText.ts
+++ b/docs/.vuepress/components/Funcs/CopyText.ts
@@ -1,0 +1,22 @@
+export default function copyText(text) {
+    try {
+        if (navigator.clipboard) {
+            navigator.clipboard.writeText(text); // use navigator.clipboard
+        } else {
+            var textarea = document.createElement("textarea");
+            document.body.appendChild(textarea);
+            // hide this input area
+            textarea.style.position = "fixed";
+            textarea.style.clip = "rect(0 0 0 0)";
+            textarea.style.top = "10px";
+            // execute
+            textarea.value = text;
+            textarea.select();
+            document.execCommand("copy", true);
+            // remove the input area
+            document.body.removeChild(textarea);
+        }
+    } catch (err) {
+        console.log(err);
+    }
+}

--- a/docs/.vuepress/components/Funcs/ImportElementStyle.ts
+++ b/docs/.vuepress/components/Funcs/ImportElementStyle.ts
@@ -5,9 +5,13 @@ import "element-plus/theme-chalk/el-col.css";
 import "element-plus/theme-chalk/el-form.css";
 import "element-plus/theme-chalk/el-form-item.css";
 import "element-plus/theme-chalk/el-input.css";
+import "element-plus/theme-chalk/el-select.css";
 import "element-plus/theme-chalk/el-tag.css";
+import "element-plus/theme-chalk/el-check-tag.css";
 import "element-plus/theme-chalk/el-message.css";
 import "element-plus/theme-chalk/el-button.css";
+import "element-plus/theme-chalk/el-divider.css";
+import "element-plus/theme-chalk/el-checkbox.css";
 
 export default function ImportElementStyle(): void {
     console.log("Components Registered");

--- a/docs/.vuepress/components/Funcs/Json2Yaml.ts
+++ b/docs/.vuepress/components/Funcs/Json2Yaml.ts
@@ -1,0 +1,94 @@
+var spacing = "  ";
+function getType(obj) {
+    var type = typeof obj;
+    if (obj instanceof Array) {
+        return "array";
+    } else if (type == "string") {
+        return "string";
+    } else if (type == "boolean") {
+        return "boolean";
+    } else if (type == "number") {
+        return "number";
+    } else if (type == "undefined" || obj === null) {
+        return "null";
+    } else {
+        return "hash";
+    }
+}
+function convert(obj, ret) {
+    var type = getType(obj);
+
+    switch (type) {
+        case "array":
+            convertArray(obj, ret);
+            break;
+        case "hash":
+            convertHash(obj, ret);
+            break;
+        case "string":
+            convertString(obj, ret);
+            break;
+        case "null":
+            ret.push("null");
+            break;
+        case "number":
+            ret.push(obj.toString());
+            break;
+        case "boolean":
+            ret.push(obj ? "true" : "false");
+            break;
+    }
+}
+function convertArray(obj, ret) {
+    if (obj.length === 0) {
+        ret.push("[]");
+    }
+    for (var i = 0; i < obj.length; i++) {
+        var ele = obj[i];
+        var recurse = [];
+        convert(ele, recurse);
+
+        for (var j = 0; j < recurse.length; j++) {
+            ret.push((j == 0 ? "- " : spacing) + recurse[j]);
+        }
+    }
+}
+function convertHash(obj, ret) {
+    for (var k in obj) {
+        var recurse = [];
+        if (obj.hasOwnProperty(k)) {
+            var ele = obj[k];
+            convert(ele, recurse);
+            var type = getType(ele);
+            if (type == "string" || type == "null" || type == "number" || type == "boolean") {
+                ret.push(normalizeString(k) + ": " + recurse[0]);
+            } else {
+                ret.push(normalizeString(k) + ": ");
+                for (var i = 0; i < recurse.length; i++) {
+                    ret.push(spacing + recurse[i]);
+                }
+            }
+        }
+    }
+}
+function normalizeString(str) {
+    if (str.match(/^[\w]+$/)) {
+        return str;
+    } else {
+        return (
+            '"' + escape(str).replace(/%u/g, "\\u").replace(/%U/g, "\\U").replace(/%/g, "\\x") + '"'
+        );
+    }
+}
+function convertString(obj, ret) {
+    ret.push(normalizeString(obj));
+}
+
+export default function json2yaml(obj) {
+    if (typeof obj == "string") {
+        obj = JSON.parse(obj);
+    }
+    var ret = [];
+    convert(obj, ret);
+    return ret.join("\n");
+}

--- a/docs/.vuepress/components/Generator.vue
+++ b/docs/.vuepress/components/Generator.vue
@@ -1,9 +1,220 @@
 <template>
-    <div>userConfigGenerator</div>
+    <el-form label-position="top" :model="FormData" style="max-width: 800px" validate>
+        <el-row class="config-users" v-for="(USER, index) of FormData.USERS" :key="USER.access_key">
+            <el-col :span="3">
+                <div class="option">
+                    <el-tag
+                        :closable="index !== 0"
+                        @close="onTagClose(index)"
+                        class="info"
+                        type="success"
+                    >
+                        用户 {{ index + 1 }}
+                    </el-tag>
+                    <el-check-tag
+                        v-show="index + 1 == USERS.length"
+                        checked
+                        class="add"
+                        @click="addUser"
+                    >
+                        +
+                    </el-check-tag>
+                </div>
+            </el-col>
+            <el-col :span="21">
+                <el-form-item label="Access_key" prop="access_key" required>
+                    <el-input
+                        v-model="USER.access_key"
+                        placeholder="请输入access_key"
+                        type="text"
+                    />
+                </el-form-item>
+                <el-form-item label="白名单" prop="white_uid">
+                    <el-input v-model="USER.white_uid" placeholder="请输入white_uid" type="text" />
+                </el-form-item>
+                <el-form-item label="黑名单" prop="banned_uid">
+                    <el-input
+                        v-model="USER.banned_uid"
+                        placeholder="请输入banned_uid"
+                        type="text"
+                    />
+                </el-form-item>
+            </el-col>
+        </el-row>
+        <el-divider />
+        <el-row class="config-details">
+            <el-col>
+                <el-form-item label="Corn表达式" prop="CRON">
+                    <el-input v-model="FormData.CRON" placeholder="请输入Corn表达式" type="text" />
+                </el-form-item>
+                <el-form-item label="Server酱SENDKEY" prop="SENDKEY">
+                    <el-input
+                        v-model="FormData.SENDKEY"
+                        placeholder="请输入Server酱SENDKEY"
+                        type="text"
+                    />
+                </el-form-item>
+                <el-form-item label="配置更多推送" prop="MOREPUSH">
+                    <el-input
+                        v-model="FormData.MOREPUSH"
+                        placeholder="请输入MOREPUSH"
+                        type="text"
+                    />
+                </el-form-item>
+            </el-col>
+            <el-col>
+                <el-form-item label="点赞间隔时间" prop="LIKE_CD">
+                    <el-input v-model="FormData.LIKE_CD" placeholder="请输入LIKE_CD" type="text" />
+                </el-form-item>
+                <el-form-item label="分享间隔时间" prop="SHARE_CD">
+                    <el-input
+                        v-model="FormData.SHARE_CD"
+                        placeholder="请输入SHARE_CD"
+                        type="text"
+                    />
+                </el-form-item>
+                <el-form-item label="弹幕间隔时间" prop="DANMAKU_CD">
+                    <el-input
+                        v-model="FormData.DANMAKU_CD"
+                        placeholder="请输入DANMAKU_CD"
+                        type="text"
+                    />
+                </el-form-item>
+            </el-col>
+            <el-col>
+                <el-form-item label="" prop="ASYNC">
+                    <el-checkbox v-model="FormData.ASYNC" border>异步执行</el-checkbox>
+                </el-form-item>
+                <el-form-item label="" prop="WEARMEDAL">
+                    <el-checkbox v-model="FormData.WEARMEDAL" border>自动更换粉丝牌</el-checkbox>
+                </el-form-item>
+            </el-col>
+            <el-col>
+                <el-button class="generateBtn" type="primary" size="large" @click="generateYAML"
+                    >生成配置文件并复制到剪切板</el-button
+                >
+            </el-col>
+        </el-row>
+    </el-form>
 </template>
 
-<script>
-export default {};
+<script setup>
+import ImportElementStyle from "./Funcs/ImportElementStyle";
+import CopyText from "./Funcs/CopyText";
+import json2yaml from "./Funcs/Json2Yaml";
+import { reactive, ref, toRaw } from "vue";
+import {
+    ElRow,
+    ElCol,
+    ElForm,
+    ElFormItem,
+    ElTag,
+    ElCheckTag,
+    ElInput,
+    ElSelect,
+    ElButton,
+    ElDivider,
+    ElCheckbox,
+    ElMessage,
+} from "element-plus";
+
+const USERS = reactive([
+    {
+        access_key: "",
+        white_uid: "",
+        banned_uid: "",
+    },
+]);
+const MOREPUSH = ref(`{"notifier":"pushplus","params":{"markdown":False,"token":"xxxxxx"}}
+`);
+const FormData = reactive({
+    USERS,
+    CRON: "",
+    SENDKEY: "",
+    MOREPUSH: MOREPUSH.value,
+    ASYNC: true,
+    LIKE_CD: 2,
+    SHARE_CD: 5,
+    DANMAKU_CD: 6,
+    WATCHINGLIVE: 1,
+    WEARMEDAL: true,
+});
+
+const processFormData = (formData) => {
+    const result = toRaw(formData);
+    result.ASYNC = result.ASYNC == true ? 1 : 0;
+    result.WEARMEDAL = result.WEARMEDAL == true ? 1 : 0;
+    // formData变化后重新调用函数，result不会重新生成，而是会继承上一次的result值
+    if (typeof result.MOREPUSH !== "object") {
+        const flag =
+            result.MOREPUSH.indexOf(`"True"`) === -1 && result.MOREPUSH.indexOf(`"False"`) === -1;
+        if (flag) {
+            result.MOREPUSH = result.MOREPUSH.replace(`False`, `"False"`);
+            result.MOREPUSH = result.MOREPUSH.replace(`True`, `"True"`);
+        }
+        result.MOREPUSH = JSON.parse(result.MOREPUSH);
+    }
+    return result;
+};
+
+const onTagClose = (index) => {
+    USERS.splice(index, 1);
+};
+
+const addUser = () => {
+    USERS.push({
+        access_key: "",
+        white_uid: "",
+        banned_uid: "",
+    });
+};
+
+const generateYAML = () => {
+    const data = json2yaml(processFormData(FormData));
+    CopyText(data);
+    ElMessage({
+        type: "success",
+        message: "配置文件已复制到剪切板",
+    });
+    console.log(data);
+};
+ImportElementStyle();
 </script>
 
-<style scoped></style>
+<style scoped>
+.el-form-item {
+    margin: 5px 5px 5px 5px;
+}
+.el-col {
+    display: flex;
+    justify-content: center;
+}
+.el-col .option {
+    justify-content: center;
+}
+.config-users .option {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+}
+.config-users .option * {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    margin-bottom: 5px;
+    height: 10px;
+}
+.config-users .option .info {
+    height: 50px;
+}
+.config-details {
+    display: flex;
+    justify-content: center;
+}
+.config-details .el-col {
+    align-items: center;
+}
+.config-details .generateBtn {
+    margin-top: 10px;
+}
+</style>

--- a/docs/.vuepress/components/Generator.vue
+++ b/docs/.vuepress/components/Generator.vue
@@ -125,14 +125,12 @@ import {
     ElCheckbox,
     ElMessage,
 } from "element-plus";
-
-const USERS = reactive([
-    {
-        access_key: "",
-        white_uid: "",
-        banned_uid: "",
-    },
-]);
+const user = {
+    access_key: "",
+    white_uid: 0,
+    banned_uid: 0,
+};
+const USERS = reactive([{ ...user }]);
 const MOREPUSH = ref(`{"notifier":"pushplus","params":{"markdown":False,"token":"xxxxxx"}}
 `);
 const FormData = reactive({
@@ -147,11 +145,14 @@ const FormData = reactive({
     WATCHINGLIVE: 1,
     WEARMEDAL: true,
 });
-
 const processFormData = (formData) => {
     const result = toRaw(formData);
     result.ASYNC = result.ASYNC == true ? 1 : 0;
     result.WEARMEDAL = result.WEARMEDAL == true ? 1 : 0;
+    result.USERS.forEach((user) => {
+        user.white_uid = user.white_uid === "" ? 0 : user.white_uid;
+        user.banned_uid = user.banned_uid === "" ? 0 : user.banned_uid;
+    });
     // formData变化后重新调用函数，result不会重新生成，而是会继承上一次的result值
     if (typeof result.MOREPUSH !== "object") {
         const flag =
@@ -164,19 +165,12 @@ const processFormData = (formData) => {
     }
     return result;
 };
-
 const onTagClose = (index) => {
     USERS.splice(index, 1);
 };
-
 const addUser = () => {
-    USERS.push({
-        access_key: "",
-        white_uid: "",
-        banned_uid: "",
-    });
+    USERS.push({ ...user });
 };
-
 const generateYAML = () => {
     const data = json2yaml(processFormData(FormData));
     const result = CopyText(data);

--- a/docs/.vuepress/components/Generator.vue
+++ b/docs/.vuepress/components/Generator.vue
@@ -179,11 +179,18 @@ const addUser = () => {
 
 const generateYAML = () => {
     const data = json2yaml(processFormData(FormData));
-    CopyText(data);
-    ElMessage({
-        type: "success",
-        message: "配置文件已复制到剪切板",
-    });
+    const result = CopyText(data);
+    if (result) {
+        ElMessage({
+            type: "success",
+            message: "配置文件已复制到剪切板",
+        });
+    } else {
+        ElMessage({
+            type: "error",
+            message: "复制失败",
+        });
+    }
     console.log(data);
 };
 ImportElementStyle();

--- a/docs/.vuepress/components/Generator.vue
+++ b/docs/.vuepress/components/Generator.vue
@@ -1,0 +1,9 @@
+<template>
+    <div>userConfigGenerator</div>
+</template>
+
+<script>
+export default {};
+</script>
+
+<style scoped></style>

--- a/docs/.vuepress/components/Generator.vue
+++ b/docs/.vuepress/components/Generator.vue
@@ -1,7 +1,7 @@
 <template>
     <el-form label-position="top" :model="FormData" style="max-width: 800px" validate>
         <el-row class="config-users" v-for="(USER, index) of FormData.USERS" :key="USER.access_key">
-            <el-col :span="3">
+            <el-col :xs="24" :sm="3" :md="3" :lg="3" :xl="3">
                 <div class="option">
                     <el-tag
                         :closable="index !== 0"
@@ -21,7 +21,7 @@
                     </el-check-tag>
                 </div>
             </el-col>
-            <el-col :span="21">
+            <el-col :xs="24" :sm="21" :md="21" :lg="21" :xl="21">
                 <el-form-item label="Access_key" prop="access_key" required>
                     <el-input
                         v-model="USER.access_key"
@@ -43,10 +43,12 @@
         </el-row>
         <el-divider />
         <el-row class="config-details">
-            <el-col>
+            <el-col :xs="12" :sm="8" :md="8" :lg="8" :xl="8">
                 <el-form-item label="Corn表达式" prop="CRON">
                     <el-input v-model="FormData.CRON" placeholder="请输入Corn表达式" type="text" />
                 </el-form-item>
+            </el-col>
+            <el-col :xs="12" :sm="8" :md="8" :lg="8" :xl="8">
                 <el-form-item label="Server酱SENDKEY" prop="SENDKEY">
                     <el-input
                         v-model="FormData.SENDKEY"
@@ -54,6 +56,8 @@
                         type="text"
                     />
                 </el-form-item>
+            </el-col>
+            <el-col :xs="12" :sm="8" :md="8" :lg="8" :xl="8">
                 <el-form-item label="配置更多推送" prop="MOREPUSH">
                     <el-input
                         v-model="FormData.MOREPUSH"
@@ -62,10 +66,12 @@
                     />
                 </el-form-item>
             </el-col>
-            <el-col>
+            <el-col :xs="12" :sm="8" :md="8" :lg="8" :xl="8">
                 <el-form-item label="点赞间隔时间" prop="LIKE_CD">
                     <el-input v-model="FormData.LIKE_CD" placeholder="请输入LIKE_CD" type="text" />
                 </el-form-item>
+            </el-col>
+            <el-col :xs="12" :sm="8" :md="8" :lg="8" :xl="8">
                 <el-form-item label="分享间隔时间" prop="SHARE_CD">
                     <el-input
                         v-model="FormData.SHARE_CD"
@@ -73,6 +79,8 @@
                         type="text"
                     />
                 </el-form-item>
+            </el-col>
+            <el-col :xs="12" :sm="8" :md="8" :lg="8" :xl="8">
                 <el-form-item label="弹幕间隔时间" prop="DANMAKU_CD">
                     <el-input
                         v-model="FormData.DANMAKU_CD"

--- a/docs/.vuepress/config.ts
+++ b/docs/.vuepress/config.ts
@@ -48,7 +48,20 @@ export default defineUserConfig({
                 ],
             },
             { text: "更新日志", link: "/changelog/" },
-            { text: "小工具", link: "/tools/" },
+            {
+                text: "小工具",
+                link: "/tools/",
+                children: [
+                    {
+                        text: "粉丝牌等级计算器",
+                        link: "/tools/fansMedalCaculator",
+                    },
+                    {
+                        text: "配置文件生成器",
+                        link: "/tools/userConfigGenerator",
+                    },
+                ],
+            },
         ],
         repo: "XiaoMiku01/fansMedalHelper",
         docsRepo: "https://github.com/XiaoMiku01/fansMedalHelperVersion",

--- a/docs/tools/README.md
+++ b/docs/tools/README.md
@@ -1,7 +1,0 @@
----
-sidebar: false
----
-
-# 粉丝牌等级计算器
-
-<div align="center"><CaculateTool /></div>

--- a/docs/tools/fansMedalCaculator.md
+++ b/docs/tools/fansMedalCaculator.md
@@ -1,0 +1,7 @@
+---
+sidebar: false
+---
+
+# 粉丝牌等级计算器
+
+<div align="center"><CaculateTool /></div>

--- a/docs/tools/userConfigGenerator.md
+++ b/docs/tools/userConfigGenerator.md
@@ -1,0 +1,7 @@
+---
+sidebar: false
+---
+
+# 配置文件生成器
+
+<div align="center"><Generator /></div>


### PR DESCRIPTION
* 手动输入`access_key`会被`validcheck`中断而失去焦点，目前还没找到解决办法。

> 好在大多数时候`access_key`都是直接粘贴来的，影响不大但是也有待修复

* 参数提示还没做，可以做成画在label旁边的图标，鼠标悬停有提示，也可以直接做成链接，点击跳转到配置说明页面

> 如果做成链接形式的实在不知道该放到哪个位置，不太优雅，所以后续还是考虑做成悬停提示样式的

* 复制操作兼容所有现代浏览器，我也测试了部分手机浏览器，能够正确生成配置并且复制到剪切板。但是QQ内置浏览器未能成功复制，针对这一点我已经加入了复制成功检测，如不成功则弹出失败提示框，后续可以考虑做成：`复制不成功则输出到界面内手动复制`
