### PR TITLE
fix: docker deployment document

### DIFF
--- a/docs/guide/other.md
+++ b/docs/guide/other.md
@@ -71,7 +71,7 @@ sidebar:
 -   拉取镜像
 
     ```shell
-    docker pull xiaomiku01/fansMedalHelper:latest
+    docker pull xiaomiku01/fansmedalhelper:latest
     ```
 
 -   创建运行容器


### PR DESCRIPTION
fix the bug that "invalid reference format: repository name must be lowercase"